### PR TITLE
Synchronize all networked variables on NetworkShow

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -597,6 +597,32 @@ namespace Unity.Netcode
             }
         }
 
+        private static readonly List<int> k_SyncDirtiedFieldIndices = new List<int>();
+
+        internal void Sync(ulong clientId)
+        {
+            for (int j = 0; j < NetworkVariableFields.Count; j++)
+            {
+                var field = NetworkVariableFields[j];
+                if (field.IsDirty())
+                {
+                    continue;
+                }
+
+                k_SyncDirtiedFieldIndices.Add(j);
+                field.SetDirty(true);
+            }
+
+            VariableUpdate(clientId);
+
+            for (int k = 0; k < k_SyncDirtiedFieldIndices.Count; k++)
+            {
+                NetworkVariableFields[k_SyncDirtiedFieldIndices[k]].ResetDirty();
+            }
+
+            k_SyncDirtiedFieldIndices.Clear();
+        }
+
         internal void WriteNetworkVariableData(FastBufferWriter writer, ulong clientId)
         {
             if (NetworkVariableFields.Count == 0)

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -215,6 +215,14 @@ namespace Unity.Netcode
         {
             SetCachedParent(transform.parent);
         }
+        
+        private void Sync(ulong clientId)
+        {
+            for (int i = 0; i < ChildNetworkBehaviours.Count; i++)
+            {
+                ChildNetworkBehaviours[i].Sync(clientId);
+            }
+        }
 
         /// <summary>
         /// Shows a previously hidden <see cref="NetworkObject"/> to a client
@@ -245,6 +253,11 @@ namespace Unity.Netcode
             Observers.Add(clientId);
 
             NetworkManager.SpawnManager.SendSpawnCallForObject(clientId, this);
+
+            if (NetworkManager.NetworkConfig.UseSnapshotSpawn)
+            {
+                Sync(clientId);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes `NetworkBehaviour` variables not replicated to remote clients for objects made visible a few frames after `CheckObjectVisibility` returned `false`.
